### PR TITLE
Rubric scrollbar, critical error catching, empty submission directory pop-up (reopened, moved)

### DIFF
--- a/src/csvgrader/Grader/grader.py
+++ b/src/csvgrader/Grader/grader.py
@@ -127,6 +127,8 @@ class Grader:
                 print(f"failed NID{netid}")
         self.numStudents = len(self.studentsSubmitted)
         print(self.numStudents, self.currentStudent)
+        if self.numStudents == 0:
+            raise RuntimeError("Can't start grading with no submissions in folder")
 
     def GenRubricItems(self):
         """Generate a rubric from the gradebook file as formatted by MyPhysics. 

--- a/src/csvgrader/gui/mainWindow.py
+++ b/src/csvgrader/gui/mainWindow.py
@@ -156,7 +156,18 @@ class MainWindow:
         self.groupGradeBtn = ttk.Checkbutton(tab, text="Grade by Group ")
         self.groupGradeBtn.grid(row=3, column=2, sticky="nw")
 
-        
+
+    def on_mousewheel_rCanvas(self, event):
+        self.rCanvas.yview_scroll(int(-1*(event.delta/120)), "units")
+
+    def enter_rubric_canvas(self, event):
+        self.mw_rCanvas_fctn = self.rFrame.bind_all("<MouseWheel>", self.on_mousewheel_rCanvas)
+
+    def exit_rubric_canvas(self, event):
+        # this may seem asymmetric with .bind_all in enter_rubric_canvas,
+        # but it works, and the function .unbind_all does not allow
+        # specifying a specific action to unbind.
+        self.rFrame.unbind("<MouseWheel>", self.mw_rCanvas_fctn)
 
     def gradeTab(self, tab):
 
@@ -168,38 +179,40 @@ class MainWindow:
         tab.grid_columnconfigure(2, weight=4)
         tab.grid_columnconfigure(3, weight=1)
 
-        rFrame = ttk.Labelframe(tab, text="Rubric")
-        #tab.add(rFrame)
+        self.rFrame = ttk.Labelframe(tab, text="Rubric")
+        #tab.add(self.rFrame)
 
-        rFrame.grid(row=0, column=0, sticky="NSWE")
-        rFrame.grid_columnconfigure(0, weight=1)
-        rFrame.grid_columnconfigure(1, weight=2)
+        self.rFrame.grid(row=0, column=0, sticky="NSWE")
+        self.rFrame.grid_columnconfigure(0, weight=1)
+        self.rFrame.grid_columnconfigure(1, weight=2)
 
         # create sub-canvas in the rubric column
         # (This scrollbar solution based on Google AI overview for search "tkinter add scrollbar to frame")
-        rCanvas = Canvas(rFrame)
-        rCanvas.pack(side="left", fill="both", expand=True)
-
-        # also create scroll bar and connect the canvas and scrollbar
-        rubric_scroll = ttk.Scrollbar(rFrame, orient="vertical", command=rCanvas.yview)
-        rubric_scroll.pack(side="right", fill="y")
-        rCanvas.configure(yscrollcommand=rubric_scroll.set)
-        rCanvas.configure(scrollregion=rCanvas.bbox("all"))
-        
-        # create rubric-subframe which is now scrollable
-        rSubFrame = ttk.Frame(rCanvas)
-        rCanvas.create_window((0,0), window=rSubFrame, anchor="nw")
+        self.rCanvas = Canvas(self.rFrame)
+        self.rCanvas.pack(side="left", fill="both", expand=True)
 
         # Bind events to Functions to update scroll region and
         # scrollbar when scrolling anywhere on canvas.
+        # When we enter the canvas, activate scroll binding, and deactivate on leaving.
+        # --> Solution to the scrollbar issues (scrolling anywhere
+        # moves the rubric) is to only bind_all on enter and leave
+        # events (see https://stackoverflow.com/a/51540768, https://stackoverflow.com/a/6433503)
+        self.rCanvas.bind("<Enter>", self.enter_rubric_canvas)
+        self.rCanvas.bind("<Leave>", self.exit_rubric_canvas)
+        
+        # create rubric-subframe which is now scrollable
+        rSubFrame = ttk.Frame(self.rCanvas)
         rSubFrame.bind(
             "<Configure>", 
-            lambda event: rCanvas.configure(scrollregion=rCanvas.bbox("all"))
+            lambda event: self.rCanvas.configure(scrollregion=self.rCanvas.bbox("all"))
         )
-        rCanvas.bind_all(
-            "<MouseWheel>",
-            lambda event: rCanvas.yview_scroll(int(-1*(event.delta/120)), "units")
-        )
+        self.rCanvas.create_window((0,0), window=rSubFrame, anchor="nw")
+
+        # also create scroll bar and connect the canvas and scrollbar
+        rubric_scroll = ttk.Scrollbar(self.rFrame, orient="vertical", command=self.rCanvas.yview)
+        rubric_scroll.pack(side="right", fill="y")
+        self.rCanvas.configure(yscrollcommand=rubric_scroll.set)
+        self.rCanvas.configure(scrollregion=self.rCanvas.bbox("all"))
 
         self.displayRubric(rSubFrame)  # display rubric is run in the sub-frame
 
@@ -417,9 +430,11 @@ class MainWindow:
         """
         netID = simpledialog.askstring(parent= self.root, title=f"Add NetID to group {self._selectedGroup}", prompt="NetID: ")
         # Check if the student is in the gradebook, if not prompt for confirmation
-        if not self.grader.getStudentInfo(netID):
+        if (netID is not None) and (not self.grader.getStudentInfo(netID)):
             if not messagebox.askyesno(parent=self.root, message="NetID not in gradebook, add anyway?"):
                 return
+        elif netID is None:
+            return  # netID is None b/c user hit "cancel" no point in prompting as above.
         self.assignToGroup(groupID=self._selectedGroup[0], NetID=netID)
     
     def deleteGroup(self):

--- a/src/csvgrader/gui/mainWindow.py
+++ b/src/csvgrader/gui/mainWindow.py
@@ -166,7 +166,7 @@ class MainWindow:
         tab.grid_columnconfigure(0, weight=6)
         tab.grid_columnconfigure(1, weight=4)
         tab.grid_columnconfigure(2, weight=4)
-        tab.grid_columnconfigure(3, weight=1) 
+        tab.grid_columnconfigure(3, weight=1)
 
         rFrame = ttk.Labelframe(tab, text="Rubric")
         #tab.add(rFrame)
@@ -174,8 +174,34 @@ class MainWindow:
         rFrame.grid(row=0, column=0, sticky="NSWE")
         rFrame.grid_columnconfigure(0, weight=1)
         rFrame.grid_columnconfigure(1, weight=2)
+
+        # create sub-canvas in the rubric column
+        # (This scrollbar solution based on Google AI overview for search "tkinter add scrollbar to frame")
+        rCanvas = Canvas(rFrame)
+        rCanvas.pack(side="left", fill="both", expand=True)
+
+        # also create scroll bar and connect the canvas and scrollbar
+        rubric_scroll = ttk.Scrollbar(rFrame, orient="vertical", command=rCanvas.yview)
+        rubric_scroll.pack(side="right", fill="y")
+        rCanvas.configure(yscrollcommand=rubric_scroll.set)
+        rCanvas.configure(scrollregion=rCanvas.bbox("all"))
         
-        self.displayRubric(rFrame)
+        # create rubric-subframe which is now scrollable
+        rSubFrame = ttk.Frame(rCanvas)
+        rCanvas.create_window((0,0), window=rSubFrame, anchor="nw")
+
+        # Bind events to Functions to update scroll region and
+        # scrollbar when scrolling anywhere on canvas.
+        rSubFrame.bind(
+            "<Configure>", 
+            lambda event: rCanvas.configure(scrollregion=rCanvas.bbox("all"))
+        )
+        rCanvas.bind_all(
+            "<MouseWheel>",
+            lambda event: rCanvas.yview_scroll(int(-1*(event.delta/120)), "units")
+        )
+
+        self.displayRubric(rSubFrame)  # display rubric is run in the sub-frame
 
         # Then display student info
         iFrame = ttk.Labelframe(tab, text="Student Info")

--- a/src/csvgrader/mainGUI.py
+++ b/src/csvgrader/mainGUI.py
@@ -1,4 +1,7 @@
 # Main.py
+
+import traceback
+
 from gui.mainWindow import MainWindow
 
 filepath = "/home/auttieb/Documents/college/TA/211LSP25/120251-PHYS-211-labs-1.csv"
@@ -8,4 +11,9 @@ submitpath = "/home/auttieb/Documents/college/TA/211LSP25/submissions/lab1/L3E"
 
 if __name__ == "__main__":
     mw = MainWindow()
-    mw.run()
+
+    try:
+        mw.run()
+    except Exception as e:
+        print("Critical Error")
+        print(traceback.print_exception(e))


### PR DESCRIPTION
I added a scrollbar for the rubric column of the Grader tab.

I also added a few lines to mainGUI.py to print any critical errors that crash the program.

Finally, since I was encountering issues when trying to point the program to an empty submissions
directory, I added a RuntimeError, which gets caught and generates a display pop-up.

Further information available in the commit messages for each of these items.

I moved the branch where I am pulling from, so as to work in feature branches.