### PR TITLE
Fix Groups CSV read and write on Windows (cross-platform)

### DIFF
--- a/src/csvgrader/dataforms/teams.py
+++ b/src/csvgrader/dataforms/teams.py
@@ -40,7 +40,12 @@ class Groups:
         if not osp.isfile(inpath):
             raise RuntimeError("Invalid Path")
         
-        with open(inpath, 'r') as f:
+        # Need to use `newline=""` to avoid extra \r on windows when
+        # working with csv.reader and csv.writer, this
+        # is still cross-platform per the documentation recommendations
+        # (See: https://docs.python.org/3/library/csv.html#csv.writer,
+        # and https://stackoverflow.com/a/3191811)
+        with open(inpath, 'r', newline="") as f:
             reader = csv.reader(f)
             header = next(reader) # Extracts the header of the CSV to ensure formatting
             if header[0] != "NetID" or header[1] != "Group":
@@ -57,7 +62,12 @@ class Groups:
             outpath (str): File path to write out 
         """
 
-        with open(outpath, "w", encoding="UTF-8") as f:
+        # Need to use `newline=""` to avoid extra \r on windows when
+        # working with csv.reader and csv.writer, this
+        # is still cross-platform per the documentation recommendations
+        # (See: https://docs.python.org/3/library/csv.html#csv.writer,
+        # and https://stackoverflow.com/a/3191811)
+        with open(outpath, "w", encoding="UTF-8", newline="") as f:
             writer = csv.writer(f)
             writer.writerow(["NetID", "Group"]) # header
             for netID, group in self._studentList.items():


### PR DESCRIPTION
On Windows, the groups.csv was being written out and gave empty lines between each name, which then could not be read back in by the program. The output might look like:

```
NetID,Group
# ( empty line )
student1,1
# ( empty line )
student2,1

```

So then `Groups.importGroups()` was failing with
IndexError at line 55 because the index 1 would
be out-of-bounds
```
for line in reader:
    self.addStudent(int(line[1]), line[0])
```

Per the documentation of csv.reader and csv.writer, the cross-platform solution is to open files and disable automatic line-ending conversion, because the csv module will handle it internally, the issue arises if both `open()` and `csv` are handling line endings, then extra carriage returns get inserted on windows.

See:
- https://docs.python.org/3/library/csv.html#csv.writer
- https://stackoverflow.com/a/3191811