### PR TITLE
Fix assignment of grade to non-existent student

### DIFF
--- a/src/csvgrader/Grader/grader.py
+++ b/src/csvgrader/Grader/grader.py
@@ -224,7 +224,11 @@ class Grader:
 
         # Ensure we don't overwrite abs or ex grades
         for cat in self.rubric.keys():
-            cg = str(self.gradebook.loc[self.gradebook["Student NetID"] == netID,self.columnIndex[cat][0]].values[0]).upper()
+            student_cg_series = self.gradebook.loc[self.gradebook["Student NetID"] == netID,self.columnIndex[cat][0]]
+            if student_cg_series.empty:
+                print(f"Student {netID} is not in the gradebook, skipping grade assignment")
+                return
+            cg = str(student_cg_series.values[0]).upper()
             if  cg == "EX" or cg == "ABS":
                 return
 


### PR DESCRIPTION
This issue is most likely to show up when grading
by group and a student in the group has dropped the class. As the group grade assignment loops over
students and runs `Grader.assignGradeStudent`,
if one student is no longer present in the
gradebook (dropped or switched sections), an
error would occur where the dataframe lookup
returns an empty dataframe, which becomes an
IndexError when accessing the zeroth element
with `.values[0]`. Thus, add a check for an
empty dataframe before accessing the current
grade to check it for ABS or EX grades.